### PR TITLE
Chore: update cors origins

### DIFF
--- a/.github/workflows/cloud_deploy_buildx.yml
+++ b/.github/workflows/cloud_deploy_buildx.yml
@@ -6,7 +6,6 @@ name: cloud_deploy_buildx
 on:
   push:
     branches:
-      - refactor/dockerfile-r-support
       - main
 
 env:

--- a/app/api/v1/endpoints/seasonal_forecast_list/router.py
+++ b/app/api/v1/endpoints/seasonal_forecast_list/router.py
@@ -1,0 +1,25 @@
+from typing import OrderedDict
+from fastapi import APIRouter, HTTPException
+from app.core.webScrape.webscraper import scrape_webpage, mw_seasonal_forecast_list_url
+
+from .schema import (
+    SeasonalForecastListParameters,
+)
+
+router = APIRouter()
+
+
+@router.post("/")
+def get_seasonal_forecast_list(
+    params: SeasonalForecastListParameters,
+) -> OrderedDict:
+        
+    if params.country == "mw":
+        districts = scrape_webpage(mw_seasonal_forecast_list_url)
+        return {"districts": districts}   
+    else:
+        raise HTTPException(status_code=404, detail=f"Seasonal Forecasts not set up '{params.country}'")
+
+
+
+

--- a/app/api/v1/endpoints/seasonal_forecast_list/schema.py
+++ b/app/api/v1/endpoints/seasonal_forecast_list/schema.py
@@ -1,0 +1,8 @@
+from typing import Literal
+from pydantic import BaseModel
+
+country_name = Literal["zm", "mw"]
+
+
+class SeasonalForecastListParameters(BaseModel):
+    country: country_name = "mw"

--- a/app/api/v1/endpoints/seasonal_forecast_pdf/router.py
+++ b/app/api/v1/endpoints/seasonal_forecast_pdf/router.py
@@ -1,0 +1,25 @@
+from typing import OrderedDict
+from fastapi import APIRouter, HTTPException
+from app.core.webScrape.webscraper import scrape_webpage, mw_seasonal_forecast_list_url
+
+from .schema import (
+    SeasonalForecastPDFParameters,
+)
+
+router = APIRouter()
+
+
+@router.post("/")
+async def get_seasonal_forecast_list(
+    params: SeasonalForecastPDFParameters,
+)-> OrderedDict:
+    if params.country == "mw":        
+        district_links = scrape_webpage(mw_seasonal_forecast_list_url)
+        # Check if link_text exists in the dictionary
+        if params.district in district_links:
+            return {"pdf_url": district_links[params.district ]}
+        else:
+            raise HTTPException(status_code=404, detail=f"PDF link not found for '{params.district}'")
+    else:
+        raise HTTPException(status_code=404, detail=f"Seasonal Forecasts not set up '{params.country}'")
+  

--- a/app/api/v1/endpoints/seasonal_forecast_pdf/schema.py
+++ b/app/api/v1/endpoints/seasonal_forecast_pdf/schema.py
@@ -1,0 +1,9 @@
+from typing import Literal
+from pydantic import BaseModel
+
+country_name = Literal["zm", "mw"]
+
+
+class SeasonalForecastPDFParameters(BaseModel):
+    country: country_name = "mw"
+    district: str = "balaka"

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -15,6 +15,12 @@ from app.api.v1.endpoints.monthly_temperature_summaries.router import (
 from app.api.v1.endpoints.season_start_probabilities.router import (
     router as season_start_probabilities_router,
 )
+from app.api.v1.endpoints.seasonal_forecast_list.router import (
+    router as seasonal_forecast_list_router,
+)
+from app.api.v1.endpoints.seasonal_forecast_pdf.router import (
+    router as seasonal_forecast_pdf_router,
+)
 from app.api.v1.endpoints.station.router import router as station_router
 from app.api.v1.endpoints.status.router import router as status_router
 
@@ -46,6 +52,16 @@ v1_router.include_router(
     season_start_probabilities_router,
     prefix="/season_start_probabilities",
     tags=["Climate"],
+)
+v1_router.include_router(
+    seasonal_forecast_list_router,
+    prefix="/seasonal_forecast_list",
+    tags=["Forecast"],
+)
+v1_router.include_router(
+    seasonal_forecast_pdf_router,
+    prefix="/seasonal_forecast_pdf",
+    tags=["Forecast"],
 )
 v1_router.include_router(station_router, prefix="/station", tags=["Work In Progress"])
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,8 +6,9 @@ from pydantic import AnyHttpUrl, BaseSettings,  validator
 
 class Settings(BaseSettings):
     EPICSA_DATA_AUTH_TOKEN: str = ''
-    # Allow cross-origin requests from development applications running on port 4200 (e-picsa angular apps)
-    BACKEND_CORS_ORIGINS: list[AnyHttpUrl] = ["http://localhost:4200"]
+    # Allow cross-origin requests
+    # Non-specific URLs to support various dev applications on localhost, and prod domains (*.picsa.app, *.vercel.app)
+    BACKEND_CORS_ORIGINS: list[AnyHttpUrl] = ["*"]
 
     @validator("BACKEND_CORS_ORIGINS", pre=True)
     def assemble_cors_origins(cls, v: Union[str, list[str]]) -> Union[list[str], str]:

--- a/app/core/webScrape/webscraper.py
+++ b/app/core/webScrape/webscraper.py
@@ -1,0 +1,33 @@
+import requests
+from bs4 import BeautifulSoup
+
+mw_seasonal_forecast_list_url = "https://www.metmalawi.gov.mw/docs/district_fcsts/"
+
+def scrape_webpage(url):
+    response = requests.get(url)
+    if response.status_code == 200:
+        # Parse the HTML content of the page using BeautifulSoup
+        soup = BeautifulSoup(response.text, 'html.parser')
+
+        link_href_dict = {}
+
+        tables = soup.find_all('table')
+        for table in tables:
+            rows = table.find_all('tr')
+            for row in rows:
+                cells = row.find_all('td')
+                for cell in cells:
+                    # Find all anchor tags (a) in the cell and append their text to the list
+                    links = cell.find_all('a')
+                    for link in links:
+                        link_text = link.text.split('_')[0]
+                        if link_text.lower() not in ["old", "parent directory"]: 
+                            link_href_dict[link_text] = url + link.get('href')
+
+        return link_href_dict
+
+    else:
+        print(f"Failed to retrieve the webpage. Status code: {response.status_code}")
+        return None
+
+

--- a/app/tests/test_get_seasonal_forcast_pdf.py
+++ b/app/tests/test_get_seasonal_forcast_pdf.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+from app.main import app 
+
+client = TestClient(app)
+
+def assert_result_structure(result):
+    assert "pdf_url" in result
+
+
+def test_get_seasonal_forecast_pdf_structure_mw_balaka():
+    # Define test input data
+    test_data = {
+        "country": "mw",
+        "district": "balaka",
+    }
+
+    # Make a request to the endpoint using the TestClient
+    response = client.post("/v1/seasonal_forecast_pdf/", json=test_data)
+
+    # Check that the response has a 200 status code
+    assert response.status_code == 200
+
+    result = response.json()
+
+    assert_result_structure(result)
+
+
+def test_get_seasonal_forecast_pdf_data_zm_error():
+    # Define test input data
+    test_data = {
+        "country": "zm",
+        "district": "anything",
+    }
+
+    # Make a request to the endpoint using the TestClient
+    response = client.post("/v1/seasonal_forecast_pdf/", json=test_data)
+
+    # Check that the response has a 200 status code
+    assert response.status_code == 404
+
+    result = response.json()
+
+    assert result["detail"] == "Seasonal Forecasts not set up 'zm'"
+
+def test_get_seasonal_forecast_pdf_data_mw_wrong_district_error():
+    # Define test input data
+    test_data = {
+        "country": "mw",
+        "district": "wrong_district",
+    }
+
+    # Make a request to the endpoint using the TestClient
+    response = client.post("/v1/seasonal_forecast_pdf/", json=test_data)
+
+    # Check that the response has a 200 status code
+    assert response.status_code == 404
+
+    result = response.json()
+
+    assert result["detail"] == "PDF link not found for 'wrong_district'"

--- a/app/tests/test_get_seasonal_forecast_list.py
+++ b/app/tests/test_get_seasonal_forecast_list.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+from app.main import app 
+
+client = TestClient(app)
+
+def assert_result_structure(result):
+    assert "districts" in result
+
+def assert_country_not_set_up_zm(result):
+    assert "detail" in result
+    assert result["detail"] == "Seasonal Forecasts not set up 'zm'"
+
+def test_get_seasonal_forecast_list_structure_mw_balaka():
+    # Define test input data
+    test_data = {
+        "country": "mw",
+    }
+
+    # Make a request to the endpoint using the TestClient
+    response = client.post("/v1/seasonal_forecast_list/", json=test_data)
+
+    # Check that the response has a 200 status code
+    assert response.status_code == 200
+
+    result = response.json()
+
+    assert_result_structure(result)
+
+
+def test_get_seasonal_forecast_list_data_zm_error():
+    # Define test input data
+    test_data = {
+        "country": "zm",
+    }
+
+    # Make a request to the endpoint using the TestClient
+    response = client.post("/v1/seasonal_forecast_list/", json=test_data)
+
+    # Check that the response has a 200 status code
+    assert response.status_code == 404
+
+    result = response.json()
+
+    assert_country_not_set_up_zm(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests==2.31.0
 pandas
 # https://github.com/rpy2/rpy2/issues/1045
 rpy2==3.5.12
+beautifulsoup4


### PR DESCRIPTION
Update list of domains supported in cross-origin requests.
Default to allow all origins, as providing a specific list of just those known would still be very permissive (localhost:4200, *.vercel.app, *.picsa.app) so unlikely to achieve much