### PR TITLE
chore: update cors origins

### DIFF
--- a/.github/workflows/cloud_deploy_buildx.yml
+++ b/.github/workflows/cloud_deploy_buildx.yml
@@ -6,7 +6,6 @@ name: cloud_deploy_buildx
 on:
   push:
     branches:
-      - refactor/dockerfile-r-support
       - main
 
 env:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,8 +6,9 @@ from pydantic import AnyHttpUrl, BaseSettings,  validator
 
 class Settings(BaseSettings):
     EPICSA_DATA_AUTH_TOKEN: str = ''
-    # Allow cross-origin requests from development applications running on port 4200 (e-picsa angular apps)
-    BACKEND_CORS_ORIGINS: list[AnyHttpUrl] = ["http://localhost:4200"]
+    # Allow cross-origin requests
+    # Non-specific URLs to support various dev applications on localhost, and prod domains (*.picsa.app, *.vercel.app)
+    BACKEND_CORS_ORIGINS: list[AnyHttpUrl] = ["*"]
 
     @validator("BACKEND_CORS_ORIGINS", pre=True)
     def assemble_cors_origins(cls, v: Union[str, list[str]]) -> Union[list[str], str]:


### PR DESCRIPTION
Update list of domains supported in cross-origin requests.

Default to allow all origins, as providing a specific list of just those known would still be very permissive (localhost:4200, *.vercel.app, *.picsa.app) so unlikely to achieve much