### PR TITLE
Chore: add station response model

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade -r requirements.txt
-        pip install --force-reinstall -r requirements_picsa.txt
 
     - name: Install R
       uses: r-lib/actions/setup-r@v2

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ The scripts below will create a python [virtual environment](https://docs.python
     python -m venv .venv
     .\.venv\Scripts\Activate.ps1
     pip install --upgrade -r requirements.txt
-    pip install --force-reinstall -r requirements_picsa.txt
     uvicorn app.main:app --reload
 
 === "Linux (bash)"
@@ -52,7 +51,6 @@ The scripts below will create a python [virtual environment](https://docs.python
     python -m venv .venv
     source .venv/bin/activate
     pip install --upgrade -r requirements.txt
-    pip install --force-reinstall -r requirements_picsa.txt
     uvicorn app.main:app --reload
 
 **R**
@@ -130,7 +128,7 @@ If facing issues with a specific package it may help to download [RStudio](https
 **Called endpoint method does not exist**
 The library calls methods from various other git repos where code is hosted both in python and R. These are installed during initial setup, but will need reinstallation whenever new versions of the external repos exist.
 
-Simply repeat the steps above to install dependencies from `requirements_picsa.txt` `install_packages_picsa.R`
+Simply repeat the steps above to install dependencies from `install_packages_picsa.R`
 
 Any other issues should be raised on GitHub
 

--- a/app/api/v1/endpoints/station/router.py
+++ b/app/api/v1/endpoints/station/router.py
@@ -1,21 +1,21 @@
-from fastapi import APIRouter, Depends, HTTPException
-from typing import Literal, OrderedDict
-from app.epicsawrap_link import station_metadata
 from fastapi import APIRouter
+from typing import OrderedDict, List
+from app.epicsawrap_link import station_metadata
 from app.api.v1.endpoints.epicsa_data import run_epicsa_function_and_get_dataframe
 from app.definitions import country_name
-
+from .schema import Station
 
 router = APIRouter()
 
-@router.get("/")
+@router.get("/",response_model=List[Station])
 def read_stations() -> OrderedDict:
-    return run_epicsa_function_and_get_dataframe(
+    res= run_epicsa_function_and_get_dataframe(
         station_metadata,
         country="",
         station_id="",
         include_definitions=True,
     )
+    return res['data']
 
 @router.get("/{country}")
 def read_stations(country: country_name ) -> OrderedDict:

--- a/app/api/v1/endpoints/station/schema.py
+++ b/app/api/v1/endpoints/station/schema.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from app.definitions import country_name
+
+class Station(BaseModel):
+    country_code: country_name
+    district: str
+    elevation: int
+    latitude: float
+    longitude: float
+    station_id: int
+    station_name: str
+    
+# TODO - define more cleanly (or generate from R?)
+# This should then either be merged with station or a 'definition' child property
+class StationDefinition(BaseModel):
+    annual_rain:str

--- a/app/api/v1/endpoints/status/router.py
+++ b/app/api/v1/endpoints/status/router.py
@@ -8,9 +8,8 @@ router = APIRouter()
 @router.get("/")
 def get_status():
     """
-    Check server up and authorized to access data
+    Check server up
     """
-    checkServiceAccount()
     # TODO - add test within epicsa wrapper to check if R installed and correct version
     return 'Server Up'
 
@@ -18,7 +17,6 @@ def get_status():
 def checkServiceAccount():
     # check for service-account.json file relative to project root
     serviceJsonPath = path.abspath('./service-account.json')
-    print('path',serviceJsonPath)
     if path.exists(serviceJsonPath):
         return True
     else:


### PR DESCRIPTION
**Main Changes**
Add a new `Station` base model used to validate station data. This doesn't include any of the station definition fields, as explicitly typing them is a bit tedious (maybe we can auto-generate from R?) and likely will want to unbind from station anyways to allow more flexibility. As these fields are not included in the model they are automatically removed from the response data

You'll also notice this now provides more example when viewing the interactive endpoint, and also provides stronger type definitions when importing into the dashboard codebase

**Example response shown**
![image](https://github.com/IDEMSInternational/epicsa-climate-api/assets/10515065/3377a84d-d538-495f-ae52-3b605df2f13c)

**Full response enforces schema** (no definition columns included)
![image](https://github.com/IDEMSInternational/epicsa-climate-api/assets/10515065/18f7fac3-b904-484d-9675-0c5bb2f4b99c)



**Additional Changes**
- Update readme to remove deprecate picsa python requirements notes
- Remove the service worker check causing issue raised in #29   


closes #29
