### PR TITLE
Refactor: forecast models

### DIFF
--- a/app/api/v1/endpoints/annual_rainfall_summaries/schema.py
+++ b/app/api/v1/endpoints/annual_rainfall_summaries/schema.py
@@ -1,6 +1,6 @@
 from typing import Literal
 from pydantic import BaseModel
-from app.definitions import country_name
+from app.definitions import country_code
 
 summary_name_annual_rainfall = Literal[
     "annual_rain",
@@ -13,7 +13,7 @@ summary_name_annual_rainfall = Literal[
 
 
 class AnnualRainfallSummariesParameters(BaseModel):
-    country: country_name = "zm"
+    country: country_code = "zm"
     station_id: str = "01122"
     summaries: list[summary_name_annual_rainfall] = [
         "annual_rain",

--- a/app/api/v1/endpoints/annual_temperature_summaries/schema.py
+++ b/app/api/v1/endpoints/annual_temperature_summaries/schema.py
@@ -1,13 +1,13 @@
 from typing import Literal
 from pydantic import BaseModel
-from app.definitions import country_name
+from app.definitions import country_code
 
 summary_name = Literal["mean_tmin", "mean_tmax"]
 
 
 
 class AnnualTemperatureSummariesParameters(BaseModel):
-    country: country_name = "zm"
+    country: country_code = "zm"
     station_id: str = "16"
     summaries: list[summary_name] = [
         "mean_tmin", 

--- a/app/api/v1/endpoints/crop_success_probabilities/schema.py
+++ b/app/api/v1/endpoints/crop_success_probabilities/schema.py
@@ -1,10 +1,10 @@
 from typing import Literal
 from pydantic import BaseModel
-from app.definitions import country_name
+from app.definitions import country_code
 
 
 class CropSuccessProbabilitiesParameters(BaseModel):
-    country: country_name = "zm"
+    country: country_code = "zm"
     station_id: str = "16"
     water_requirements: list[int] | None = None
     planting_length: list[int] | None = None

--- a/app/api/v1/endpoints/extremes_summaries/schema.py
+++ b/app/api/v1/endpoints/extremes_summaries/schema.py
@@ -1,6 +1,6 @@
 from typing import Literal
 from pydantic import BaseModel
-from app.definitions import country_name
+from app.definitions import country_code
 
 summary_name_extremes_summaries = Literal[
     "extremes_rain",
@@ -9,7 +9,7 @@ summary_name_extremes_summaries = Literal[
 ]
 
 class ExtremesSummariesParameters(BaseModel):
-    country: country_name = "zm"
+    country: country_code = "zm"
     station_id: str = "test_1"
     summaries: list[summary_name_extremes_summaries] = [
         "extremes_rain",

--- a/app/api/v1/endpoints/forecasts/schema.py
+++ b/app/api/v1/endpoints/forecasts/schema.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Literal, Optional
+from app.definitions import  country_code, language_code as lang_code
+
+class Forecast(BaseModel):
+    country_code
+    date_modified:datetime 
+    district:Optional[str]=None
+    filename:str
+    id:str
+    language_code:Optional[lang_code] = None
+    type:Optional[Literal["downscale_forecast"]] = None

--- a/app/api/v1/endpoints/forecasts/schema.py
+++ b/app/api/v1/endpoints/forecasts/schema.py
@@ -10,4 +10,4 @@ class Forecast(BaseModel):
     filename:str
     id:str
     language_code:Optional[lang_code] = None
-    type:Optional[Literal["downscale_forecast"]] = None
+    type:Optional[Literal["downscale_forecast", "annual_forecast"]] = None

--- a/app/api/v1/endpoints/monthly_temperature_summaries/schema.py
+++ b/app/api/v1/endpoints/monthly_temperature_summaries/schema.py
@@ -1,11 +1,11 @@
 from typing import Literal
 from pydantic import BaseModel
-from app.definitions import country_name
+from app.definitions import country_code
 
 summary_name = Literal["mean_tmin", "mean_tmax"]
 
 
 class MonthlyTemperatureSummariesParameters(BaseModel):
-    country: country_name = "zm"
+    country: country_code = "zm"
     station_id: str = "16"
     summaries: list[summary_name] = ["mean_tmin", "mean_tmax"]

--- a/app/api/v1/endpoints/season_start_probabilities/schema.py
+++ b/app/api/v1/endpoints/season_start_probabilities/schema.py
@@ -1,9 +1,9 @@
 from typing import Literal
 from pydantic import BaseModel
-from app.definitions import country_name
+from app.definitions import country_code
 
 
 class SeasonStartProbabilitiesParameters(BaseModel):
-    country: country_name = "zm"
+    country: country_code = "zm"
     station_id: str = "16"
     start_dates: list[int] | None = None

--- a/app/api/v1/endpoints/station/router.py
+++ b/app/api/v1/endpoints/station/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from typing import OrderedDict, List
 from app.epicsawrap_link import station_metadata
 from app.api.v1.endpoints.epicsa_data import run_epicsa_function_and_get_dataframe
-from app.definitions import country_name
+from app.definitions import country_code
 from .schema import Station
 
 router = APIRouter()
@@ -18,7 +18,7 @@ def read_stations() -> OrderedDict:
     return res['data']
 
 @router.get("/{country}")
-def read_stations(country: country_name ) -> OrderedDict:
+def read_stations(country: country_code ) -> OrderedDict:
     return run_epicsa_function_and_get_dataframe(
         station_metadata,
         country=country,
@@ -27,7 +27,7 @@ def read_stations(country: country_name ) -> OrderedDict:
     )
 
 @router.get("/{country}/{station_id}")
-def read_stations(country: country_name, station_id:str ) -> OrderedDict:
+def read_stations(country: country_code, station_id:str ) -> OrderedDict:
     return run_epicsa_function_and_get_dataframe(
         station_metadata,
         country=country,

--- a/app/api/v1/endpoints/station/schema.py
+++ b/app/api/v1/endpoints/station/schema.py
@@ -1,8 +1,8 @@
 from pydantic import BaseModel
-from app.definitions import country_name
+from app.definitions import country_code
 
 class Station(BaseModel):
-    country_code: country_name
+    country_code: country_code
     district: str
     elevation: int
     latitude: float

--- a/app/definitions.py
+++ b/app/definitions.py
@@ -1,4 +1,10 @@
 from typing import Literal
 
 
-country_name = Literal["zm", "mw"]
+# ISO 3166 country code (https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
+# alpha-2 used where available
+country_code = Literal['zm','mw']
+
+# ISO 639 language code (https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes)
+# set 1 used where available
+language_code = Literal['en','ny']


### PR DESCRIPTION
NOTE - built on top of #30 so should be updated once merged for cleaner diffs

## Main Changes
- Add a forecast basemodel to improve data consistency and exportable type definitions
- Update `/forecasts` endpoint to simply provide a list of available endpoints by country
- Add `/forecasts/{country_code}` endpoint to return forecasts just for a single country
It's unlikely the dashboard would ever need to retrieve multiple countries simultaneously, should hopefully simplify endpoints when only dealing with a single bucket each request

- Remove string `'error'` values for extracted forecast metdata (prefer to return None) 

## Additional Changes
- Replace the `country_name` type literal with `country_code` to better reflect using iso codes
- Add `language_code` type literal to ensure populated data matches expected language codes

## Screenshots
**Example dashboard** - accessing data includes string `'error'` values which can be a bit confusing
![image](https://github.com/IDEMSInternational/epicsa-climate-api/assets/10515065/3e93ea86-e3ab-4796-b7dc-14a35c77c58c)

**API forecast data by station**
![image](https://github.com/IDEMSInternational/epicsa-climate-api/assets/10515065/01f9196f-3cd3-441e-aca5-4e7a3623cc2c)