### PR TITLE
fix: forecast literal type fallback

### DIFF
--- a/app/api/v1/endpoints/forecasts/router.py
+++ b/app/api/v1/endpoints/forecasts/router.py
@@ -4,7 +4,8 @@ from fastapi.responses import StreamingResponse,FileResponse
 from google.cloud import storage
 from typing import get_args, List
 from app.definitions import country_code
-from .schema import Forecast
+from app.utils.model import with_fallback
+from .schema import Forecast, ForecastType
 import os
 
 client = storage.Client.from_service_account_json('service-account.json')
@@ -26,7 +27,7 @@ def get_metadata_from_name(filename: str):
     if len(parts) > 2:
         return {
             "district": parts[0],
-            "type" : parts[1],
+            "type" : with_fallback(parts[1],ForecastType,None),
             "language" : parts[2]
             }
     else:

--- a/app/api/v1/endpoints/forecasts/schema.py
+++ b/app/api/v1/endpoints/forecasts/schema.py
@@ -3,6 +3,8 @@ from pydantic import BaseModel
 from typing import Literal, Optional
 from app.definitions import  country_code, language_code as lang_code
 
+ForecastType = Literal["downscaled_forecast", "annual_forecast"]
+
 class Forecast(BaseModel):
     country_code
     date_modified:datetime 
@@ -10,4 +12,4 @@ class Forecast(BaseModel):
     filename:str
     id:str
     language_code:Optional[lang_code] = None
-    type:Optional[Literal["downscale_forecast", "annual_forecast"]] = None
+    type:Optional[ForecastType] = None

--- a/app/utils/model.py
+++ b/app/utils/model.py
@@ -1,0 +1,13 @@
+from typing import Literal
+
+def with_fallback(value:str, expected:Literal[None], fallback:str | None):
+    """Provide a fallback value when assigning a str value to a literal type
+    Args:
+        value (str): String value to check
+        expected (Literal): Literal model to check for valid string
+        fallback (str | None): Value to return when input value does not satisfy literal type
+    """
+    if(value in expected.__args__):
+        return value
+    else:
+        return fallback


### PR DESCRIPTION
When retrieving forecasts internal errors are thrown due to forecast type not satisfying the model imposed in #31.

This is due to a minor discrepency in the storage buckets used, where mw included `downscaled_forecast` but zm `downscale_forecast`. I believe the correct term should be `downscaled`.

It would be good to address this at the bucket level, although as these sorts of typos may not always be preventable.
This PR adds a small utility function that allows providing fallback options when trying assign values to a Literal type.