### PR TITLE
Added response models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ working_data/
 
 # service account key
 service-account.json
+ENV_DIR/

--- a/app/api/v1/endpoints/annual_rainfall_summaries/router.py
+++ b/app/api/v1/endpoints/annual_rainfall_summaries/router.py
@@ -12,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/")#, response_model=AnnualRainfallSummariesResponce)
+@router.post("/", response_model=AnnualRainfallSummariesResponce)
 def get_annual_rainfall_summaries(
     params: AnnualRainfallSummariesParameters
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/annual_rainfall_summaries/router.py
+++ b/app/api/v1/endpoints/annual_rainfall_summaries/router.py
@@ -3,6 +3,7 @@ from typing import OrderedDict
 from app.epicsawrap_link import annual_rainfall_summaries
 from fastapi import APIRouter
 from app.api.v1.endpoints.epicsa_data import run_epicsa_function_and_get_dataframe
+from app.core.responce_models.rainfall_summaries_responce_model import AnnualRainfallSummariesResponce
 
 from .schema import (
     AnnualRainfallSummariesParameters,
@@ -11,9 +12,9 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/")
+@router.post("/")#, response_model=AnnualRainfallSummariesResponce)
 def get_annual_rainfall_summaries(
-    params: AnnualRainfallSummariesParameters,
+    params: AnnualRainfallSummariesParameters
 ) -> OrderedDict:
     
     return run_epicsa_function_and_get_dataframe(

--- a/app/api/v1/endpoints/annual_rainfall_summaries/schema.py
+++ b/app/api/v1/endpoints/annual_rainfall_summaries/schema.py
@@ -14,7 +14,7 @@ summary_name_annual_rainfall = Literal[
 
 class AnnualRainfallSummariesParameters(BaseModel):
     country: country_code = "zm"
-    station_id: str = "01122"
+    station_id: str = "test_1"
     summaries: list[summary_name_annual_rainfall] = [
         "annual_rain",
         "start_rains",
@@ -23,3 +23,4 @@ class AnnualRainfallSummariesParameters(BaseModel):
         "seasonal_rain",
         "seasonal_length",
     ]
+

--- a/app/api/v1/endpoints/annual_temperature_summaries/router.py
+++ b/app/api/v1/endpoints/annual_temperature_summaries/router.py
@@ -12,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/")#, response_model=AnnualTemperatureSummariesResponce)
+@router.post("/", response_model=AnnualTemperatureSummariesResponce)
 def get_annual_temperature_summaries(
     params: AnnualTemperatureSummariesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/annual_temperature_summaries/router.py
+++ b/app/api/v1/endpoints/annual_temperature_summaries/router.py
@@ -12,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/", response_model=AnnualTemperatureSummariesResponce)
+@router.post("/")#, response_model=AnnualTemperatureSummariesResponce)
 def get_annual_temperature_summaries(
     params: AnnualTemperatureSummariesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/annual_temperature_summaries/router.py
+++ b/app/api/v1/endpoints/annual_temperature_summaries/router.py
@@ -1,4 +1,5 @@
 from typing import OrderedDict
+from app.core.responce_models.temperature_responce_model import AnnualTemperatureSummariesResponce
 
 from app.epicsawrap_link  import annual_temperature_summaries
 from fastapi import APIRouter
@@ -11,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/")
+@router.post("/", response_model=AnnualTemperatureSummariesResponce)
 def get_annual_temperature_summaries(
     params: AnnualTemperatureSummariesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/annual_temperature_summaries/schema.py
+++ b/app/api/v1/endpoints/annual_temperature_summaries/schema.py
@@ -14,7 +14,7 @@ summary_name = Literal[
 
 class AnnualTemperatureSummariesParameters(BaseModel):
     country: country_code = "zm"
-    station_id: str = "test_1"
+    station_id: str = "1"
     summaries: list[summary_name] = [
         "mean_tmin", 
         "mean_tmax",

--- a/app/api/v1/endpoints/annual_temperature_summaries/schema.py
+++ b/app/api/v1/endpoints/annual_temperature_summaries/schema.py
@@ -2,14 +2,27 @@ from typing import Literal
 from pydantic import BaseModel
 from app.definitions import country_code
 
-summary_name = Literal["mean_tmin", "mean_tmax"]
+summary_name = Literal[
+    "mean_tmin", 
+    "mean_tmax",
+    "min_tmin",
+    "min_tmax",
+    "max_tmin",
+    "max_tmax"]
 
 
 
 class AnnualTemperatureSummariesParameters(BaseModel):
     country: country_code = "zm"
-    station_id: str = "16"
+    station_id: str = "test_1"
     summaries: list[summary_name] = [
         "mean_tmin", 
-        "mean_tmax"
+        "mean_tmax",
+        "min_tmin",
+        "min_tmax",
+        "max_tmin",
+        "max_tmax"
+
     ]
+
+

--- a/app/api/v1/endpoints/annual_temperature_summaries/schema.py
+++ b/app/api/v1/endpoints/annual_temperature_summaries/schema.py
@@ -14,7 +14,7 @@ summary_name = Literal[
 
 class AnnualTemperatureSummariesParameters(BaseModel):
     country: country_code = "zm"
-    station_id: str = "1"
+    station_id: str = "test_1"
     summaries: list[summary_name] = [
         "mean_tmin", 
         "mean_tmax",

--- a/app/api/v1/endpoints/crop_success_probabilities/router.py
+++ b/app/api/v1/endpoints/crop_success_probabilities/router.py
@@ -3,6 +3,7 @@ from typing import OrderedDict
 from app.epicsawrap_link  import crop_success_probabilities
 from fastapi import APIRouter
 from app.api.v1.endpoints.epicsa_data import run_epicsa_function_and_get_dataframe
+from app.core.responce_models.crop_success_probabilities_model import CropSuccessProbabilitiesResponce
 
 from .schema import (
     CropSuccessProbabilitiesParameters,
@@ -11,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/")
+@router.post("/",response_model=CropSuccessProbabilitiesResponce)
 def get_crop_success_probabilities(
     params: CropSuccessProbabilitiesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/crop_success_probabilities/schema.py
+++ b/app/api/v1/endpoints/crop_success_probabilities/schema.py
@@ -6,7 +6,7 @@ from app.definitions import country_code
 class CropSuccessProbabilitiesParameters(BaseModel):
     country: country_code = "zm"
     station_id: str = "1"
-    water_requirements: list[int] | None = [300, 500, 700]
-    planting_length: list[int] | None = [120, 180]
-    planting_dates: list[int] | None = [92, 122, 153]
+    water_requirements: list[int] | None = [100, 200, 300]
+    planting_length: list[int] | None = [20]
+    planting_dates: list[int] | None = [25, 50, 75]
     start_before_season: bool | None = True

--- a/app/api/v1/endpoints/crop_success_probabilities/schema.py
+++ b/app/api/v1/endpoints/crop_success_probabilities/schema.py
@@ -5,7 +5,7 @@ from app.definitions import country_code
 
 class CropSuccessProbabilitiesParameters(BaseModel):
     country: country_code = "zm"
-    station_id: str = "test_1"
+    station_id: str = "1"
     water_requirements: list[int] | None = [300, 500, 700]
     planting_length: list[int] | None = [120, 180]
     planting_dates: list[int] | None = [92, 122, 153]

--- a/app/api/v1/endpoints/crop_success_probabilities/schema.py
+++ b/app/api/v1/endpoints/crop_success_probabilities/schema.py
@@ -5,8 +5,8 @@ from app.definitions import country_code
 
 class CropSuccessProbabilitiesParameters(BaseModel):
     country: country_code = "zm"
-    station_id: str = "16"
-    water_requirements: list[int] | None = None
-    planting_length: list[int] | None = None
-    planting_dates: list[int] | None = None
-    start_before_season: bool | None = None
+    station_id: str = "test_1"
+    water_requirements: list[int] | None = [300, 500, 700]
+    planting_length: list[int] | None = [120, 180]
+    planting_dates: list[int] | None = [92, 122, 153]
+    start_before_season: bool | None = True

--- a/app/api/v1/endpoints/extremes_summaries/router.py
+++ b/app/api/v1/endpoints/extremes_summaries/router.py
@@ -3,6 +3,7 @@ from typing import OrderedDict
 from app.epicsawrap_link import extremes_summaries
 from fastapi import APIRouter
 from app.api.v1.endpoints.epicsa_data import run_epicsa_function_and_get_dataframe
+from app.core.responce_models.extremes_summaries_responce_model import ExtremesSummariesResponce
 
 from .schema import (
     ExtremesSummariesParameters,
@@ -11,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/")
+@router.post("/",response_model=ExtremesSummariesResponce)
 def get_extremes_summaries(
     params: ExtremesSummariesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/extremes_summaries/router.py
+++ b/app/api/v1/endpoints/extremes_summaries/router.py
@@ -12,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/",response_model=ExtremesSummariesResponce)
+@router.post("/")#,response_model=ExtremesSummariesResponce)
 def get_extremes_summaries(
     params: ExtremesSummariesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/monthly_temperature_summaries/router.py
+++ b/app/api/v1/endpoints/monthly_temperature_summaries/router.py
@@ -12,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/")#,response_model=MonthlyTemperatureSummariesResponce)
+@router.post("/",response_model=MonthlyTemperatureSummariesResponce)
 def get_monthly_temperature_summaries(
     params: MonthlyTemperatureSummariesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/monthly_temperature_summaries/router.py
+++ b/app/api/v1/endpoints/monthly_temperature_summaries/router.py
@@ -3,6 +3,7 @@ from typing import OrderedDict
 from app.epicsawrap_link import monthly_temperature_summaries
 from fastapi import APIRouter
 from app.api.v1.endpoints.epicsa_data import run_epicsa_function_and_get_dataframe
+from app.core.responce_models.temperature_responce_model import MonthlyTemperatureSummariesResponce
 
 from .schema import (
     MonthlyTemperatureSummariesParameters,
@@ -11,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/")
+@router.post("/",response_model=MonthlyTemperatureSummariesResponce)
 def get_monthly_temperature_summaries(
     params: MonthlyTemperatureSummariesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/monthly_temperature_summaries/router.py
+++ b/app/api/v1/endpoints/monthly_temperature_summaries/router.py
@@ -12,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/",response_model=MonthlyTemperatureSummariesResponce)
+@router.post("/")#,response_model=MonthlyTemperatureSummariesResponce)
 def get_monthly_temperature_summaries(
     params: MonthlyTemperatureSummariesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/monthly_temperature_summaries/schema.py
+++ b/app/api/v1/endpoints/monthly_temperature_summaries/schema.py
@@ -7,5 +7,12 @@ summary_name = Literal["mean_tmin", "mean_tmax"]
 
 class MonthlyTemperatureSummariesParameters(BaseModel):
     country: country_code = "zm"
-    station_id: str = "16"
-    summaries: list[summary_name] = ["mean_tmin", "mean_tmax"]
+    station_id: str = "test_1"
+    summaries: list[summary_name] = [
+        "mean_tmin", 
+        "mean_tmax",
+        "min_tmin",
+        "min_tmax",
+        "max_tmin",
+        "max_tmax"
+        ]

--- a/app/api/v1/endpoints/monthly_temperature_summaries/schema.py
+++ b/app/api/v1/endpoints/monthly_temperature_summaries/schema.py
@@ -11,8 +11,8 @@ class MonthlyTemperatureSummariesParameters(BaseModel):
     summaries: list[summary_name] = [
         "mean_tmin", 
         "mean_tmax",
-        "min_tmin",
-        "min_tmax",
-        "max_tmin",
-        "max_tmax"
+      #  "min_tmin",
+      #  "min_tmax",
+      #  "max_tmin",
+      #  "max_tmax"
         ]

--- a/app/api/v1/endpoints/season_start_probabilities/router.py
+++ b/app/api/v1/endpoints/season_start_probabilities/router.py
@@ -12,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/",response_model=SeasonStartProbabilitiesResponce)
+@router.post("/")#,response_model=SeasonStartProbabilitiesResponce)
 def get_season_start_probabilities(
     params: SeasonStartProbabilitiesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/season_start_probabilities/router.py
+++ b/app/api/v1/endpoints/season_start_probabilities/router.py
@@ -3,6 +3,7 @@ from typing import OrderedDict
 from app.epicsawrap_link import season_start_probabilities
 from fastapi import APIRouter
 from app.api.v1.endpoints.epicsa_data import run_epicsa_function_and_get_dataframe
+from app.core.responce_models.season_start_probabilities import SeasonStartProbabilitiesResponce
 
 from .schema import (
     SeasonStartProbabilitiesParameters,
@@ -11,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/")
+@router.post("/",response_model=SeasonStartProbabilitiesResponce)
 def get_season_start_probabilities(
     params: SeasonStartProbabilitiesParameters,
 ) -> OrderedDict:

--- a/app/api/v1/endpoints/season_start_probabilities/schema.py
+++ b/app/api/v1/endpoints/season_start_probabilities/schema.py
@@ -5,5 +5,5 @@ from app.definitions import country_code
 
 class SeasonStartProbabilitiesParameters(BaseModel):
     country: country_code = "zm"
-    station_id: str = "16"
-    start_dates: list[int] | None = None
+    station_id: str = "test_1"
+    start_dates: list[int] | None = [200, 220, 250, 270, 300, 320]

--- a/app/api/v1/endpoints/station/router.py
+++ b/app/api/v1/endpoints/station/router.py
@@ -28,7 +28,7 @@ def read_stations(country: country_code ) -> OrderedDict:
     )
     return res['data']
 
-@router.get("/{country}/{station_id}")#,response_model=StationAndDefintionResponce)
+@router.get("/{country}/{station_id}",response_model=StationAndDefintionResponce)
 def read_stations(country: country_code, station_id:str ): #-> OrderedDict:
     res = station_metadata(
         country=country,

--- a/app/api/v1/endpoints/station/router.py
+++ b/app/api/v1/endpoints/station/router.py
@@ -3,35 +3,38 @@ from typing import OrderedDict, List
 from app.epicsawrap_link import station_metadata
 from app.api.v1.endpoints.epicsa_data import run_epicsa_function_and_get_dataframe
 from app.definitions import country_code
+from app.core.responce_models.station_responce_model import StationDataResponce,StationDefinitionDataResponce
 from .schema import Station
 
 router = APIRouter()
 
-@router.get("/",response_model=List[Station])
+@router.get("/",response_model=List[StationDataResponce])
 def read_stations() -> OrderedDict:
-    res= run_epicsa_function_and_get_dataframe(
+    res = run_epicsa_function_and_get_dataframe(
         station_metadata,
         country="",
         station_id="",
-        include_definitions=True,
+        include_definitions=False,
     )
     return res['data']
 
-@router.get("/{country}")
+@router.get("/{country}",response_model=List[StationDataResponce])
 def read_stations(country: country_code ) -> OrderedDict:
-    return run_epicsa_function_and_get_dataframe(
+    res = run_epicsa_function_and_get_dataframe(
         station_metadata,
         country=country,
         station_id="",
-        include_definitions=True,
+        include_definitions=False,
     )
+    return res['data']
 
-@router.get("/{country}/{station_id}")
+@router.get("/{country}/{station_id}")#,response_model=StationDefinitionDataResponce)
 def read_stations(country: country_code, station_id:str ) -> OrderedDict:
-    return run_epicsa_function_and_get_dataframe(
+    res = run_epicsa_function_and_get_dataframe(
         station_metadata,
         country=country,
         station_id=station_id,
         include_definitions=True,
     )
+    return res['data'][0]
 

--- a/app/api/v1/endpoints/station/router.py
+++ b/app/api/v1/endpoints/station/router.py
@@ -3,7 +3,7 @@ from typing import OrderedDict, List
 from app.epicsawrap_link import station_metadata
 from app.api.v1.endpoints.epicsa_data import run_epicsa_function_and_get_dataframe
 from app.definitions import country_code
-from app.core.responce_models.station_responce_model import StationDataResponce,StationDefinitionDataResponce
+from app.core.responce_models.station_responce_model import StationDataResponce,StationAndDefintionResponce
 from .schema import Station
 
 router = APIRouter()
@@ -28,13 +28,12 @@ def read_stations(country: country_code ) -> OrderedDict:
     )
     return res['data']
 
-@router.get("/{country}/{station_id}")#,response_model=StationDefinitionDataResponce)
-def read_stations(country: country_code, station_id:str ) -> OrderedDict:
-    res = run_epicsa_function_and_get_dataframe(
-        station_metadata,
+@router.get("/{country}/{station_id}")#,response_model=StationAndDefintionResponce)
+def read_stations(country: country_code, station_id:str ): #-> OrderedDict:
+    res = station_metadata(
         country=country,
         station_id=station_id,
         include_definitions=True,
     )
-    return res['data'][0]
+    return res
 

--- a/app/api/v1/endpoints/station/schema.py
+++ b/app/api/v1/endpoints/station/schema.py
@@ -10,7 +10,3 @@ class Station(BaseModel):
     station_id: int
     station_name: str
     
-# TODO - define more cleanly (or generate from R?)
-# This should then either be merged with station or a 'definition' child property
-class StationDefinition(BaseModel):
-    annual_rain:str

--- a/app/core/responce_models/crop_success_probabilities_model.py
+++ b/app/core/responce_models/crop_success_probabilities_model.py
@@ -11,9 +11,9 @@ class CropSuccessProbabilitiesMetadata(BaseModel):
 
 class CropSuccessProbabilitiesdata(BaseModel):
     station: str
-    water_requirements : int
-    planting_dates : int
-    planting_length : int
+    rain_total : int
+    plant_day : int
+    plant_length : int
     prop_success : float
 
 class CropSuccessProbabilitiesResponce(BaseModel):

--- a/app/core/responce_models/crop_success_probabilities_model.py
+++ b/app/core/responce_models/crop_success_probabilities_model.py
@@ -1,0 +1,21 @@
+from datetime import date
+from pydantic import BaseModel
+from typing import List, Optional
+
+from app.core.responce_models.definitions_responce_model import CropsSuccess, EndRains, StartRains
+
+class CropSuccessProbabilitiesMetadata(BaseModel):
+    start_rains: Optional[StartRains]
+    end_rains:Optional[EndRains]
+    crops_success:Optional[CropsSuccess]
+
+class CropSuccessProbabilitiesdata(BaseModel):
+    station: str
+    water_requirements : int
+    planting_dates : int
+    planting_length : int
+    prop_success : float
+
+class CropSuccessProbabilitiesResponce(BaseModel):
+    metadata: CropSuccessProbabilitiesMetadata
+    data: list[CropSuccessProbabilitiesdata]

--- a/app/core/responce_models/definitions_responce_model.py
+++ b/app/core/responce_models/definitions_responce_model.py
@@ -1,0 +1,76 @@
+from datetime import date
+from pydantic import BaseModel
+from typing import Dict, List, Optional
+
+class AnnualRain(BaseModel):
+    annual_rain: Optional[bool]
+    n_rain : Optional[bool]
+    na_rm : Optional[bool]
+
+class StartRains(BaseModel):
+    threshold: Optional[int]
+    s_start_doy: Optional[int]
+    start_day: Optional[int]
+    end_day: Optional[int]
+    total_rainfall: Optional[bool]
+    amount_rain: Optional[int]
+    over_days: Optional[int]
+    proportion: Optional[bool]
+    number_rain_days: Optional[bool]
+    dry_spell: Optional[bool]
+    spell_max_dry_days: Optional[int]
+    spell_interval: Optional[int]
+    dry_period: Optional[bool]
+    _last_updated: Optional[date]
+
+class EndRains(BaseModel):
+    s_start_doy: Optional[int]
+    start_day: Optional[int]
+    end_day: Optional[int]
+    interval_length: Optional[int]
+    min_rainfall: Optional[int]
+    
+class EndSeason(BaseModel):
+    s_start_doy : Optional[int]
+    start_day: Optional[int]
+    end_day: Optional[int]
+    capacity: Optional[int]
+    water_balance_max: Optional[int]
+    evaporation: Optional[str]
+    evaporation_value: Optional[int]
+   
+class SeasonalRain(BaseModel):
+    seasonal_rain: Optional[bool]
+    end_type: Optional[str]
+    total_rain: Optional[bool]
+    n_rain: Optional[bool]
+    na_rm: Optional[bool]
+    rain_day: Optional[float]
+
+class SeasonalLength(BaseModel):
+    end_type : Optional[str]
+
+class SeasonalTotalRainfall(BaseModel):
+    na_prop: Optional[float]
+
+class Temp(BaseModel):
+    to: Optional[str]
+    na_rm : Optional[bool]
+
+class ExtremesRain(BaseModel):
+    type: Optional[str]
+    value : Optional[int]
+
+class ExtremesTemp(BaseModel):   
+    direction: Optional[str]
+    type: Optional[str]
+    value: Optional[int]
+
+class CropsSuccess(BaseModel):
+    water_requirements : Optional[Dict[str, int]] #val1, val2, valx
+    planting_dates: Optional[Dict[str, int]] #val1, val2, valx
+    planting_length: Optional[Dict[str, int]] #val1, val2, valx
+    start_check: Optional[bool]
+
+class SeasonStartProbabilities(BaseModel):
+    specified_day: Optional[List[int]]

--- a/app/core/responce_models/definitions_responce_model.py
+++ b/app/core/responce_models/definitions_responce_model.py
@@ -6,32 +6,41 @@ class AnnualRain(BaseModel):
     annual_rain: Optional[bool]
     n_rain : Optional[bool]
     na_rm : Optional[bool]
+    na_prop : Optional[float]
+    na_n : Optional[int]
+    na_consec : Optional[int]
+    na_n_non : Optional[int]
 
 class StartRains(BaseModel):
     threshold: Optional[int]
-    s_start_doy: Optional[int]
     start_day: Optional[int]
     end_day: Optional[int]
     total_rainfall: Optional[bool]
     amount_rain: Optional[int]
     over_days: Optional[int]
     proportion: Optional[bool]
+    prob_rain_day: Optional[float]
     number_rain_days: Optional[bool]
+    min_rain_days: Optional[int]
+    rain_day_interval: Optional[int]
     dry_spell: Optional[bool]
     spell_max_dry_days: Optional[int]
     spell_interval: Optional[int]
     dry_period: Optional[bool]
+    period_interval: Optional[int]
+    max_rain: Optional[int]
+    period_max_dry_days: Optional[int]
     _last_updated: Optional[date]
 
 class EndRains(BaseModel):
-    s_start_doy: Optional[int]
+  #  s_start_doy: Optional[int]
     start_day: Optional[int]
     end_day: Optional[int]
     interval_length: Optional[int]
     min_rainfall: Optional[int]
     
 class EndSeason(BaseModel):
-    s_start_doy : Optional[int]
+  #  s_start_doy : Optional[int]
     start_day: Optional[int]
     end_day: Optional[int]
     capacity: Optional[int]
@@ -40,12 +49,16 @@ class EndSeason(BaseModel):
     evaporation_value: Optional[int]
    
 class SeasonalRain(BaseModel):
-    seasonal_rain: Optional[bool]
+  #  seasonal_rain: Optional[bool]
+    total_rain: Optional[int] | Optional[bool]
     end_type: Optional[str]
-    total_rain: Optional[bool]
     n_rain: Optional[bool]
-    na_rm: Optional[bool]
     rain_day: Optional[float]
+    na_rm: Optional[bool]
+    na_prop: Optional[float]
+    na_n: Optional[int]
+    na_consec: Optional[int]
+    na_n_non: Optional[int]
 
 class SeasonalLength(BaseModel):
     end_type : Optional[str]
@@ -73,4 +86,4 @@ class CropsSuccess(BaseModel):
     start_check: Optional[bool]
 
 class SeasonStartProbabilities(BaseModel):
-    specified_day: Optional[List[int]]
+    specified_day: Optional[Dict[str, int]]

--- a/app/core/responce_models/extremes_summaries_responce_model.py
+++ b/app/core/responce_models/extremes_summaries_responce_model.py
@@ -1,0 +1,26 @@
+from datetime import date
+from pydantic import BaseModel
+from typing import List, Optional
+
+from app.core.responce_models.definitions_responce_model import ExtremesRain, ExtremesTemp
+
+class ExtremesSummariesMetadata(BaseModel):
+    extremes_rain: Optional[ExtremesRain]
+    extremes_tmin : Optional[ExtremesTemp]
+    extremes_tmax : Optional[ExtremesTemp]
+
+class ExtremesSummariesdata(BaseModel):
+    station: str
+    date: float #should be date
+    year: int
+    month : int
+    doy: int
+    day: int
+    tmax: float
+    tmin: float
+    rain: float
+
+
+class ExtremesSummariesResponce(BaseModel):
+    metadata: ExtremesSummariesMetadata
+    data: list[ExtremesSummariesdata]

--- a/app/core/responce_models/rainfall_summaries_responce_model.py
+++ b/app/core/responce_models/rainfall_summaries_responce_model.py
@@ -1,0 +1,31 @@
+from datetime import date
+from pydantic import BaseModel
+from typing import List, Optional
+
+from app.core.responce_models.definitions_responce_model import AnnualRain, EndRains, EndSeason, SeasonalLength, SeasonalRain, StartRains
+
+class AnnualRainfallSummariesMetadata(BaseModel):
+    annual_rain: Optional[AnnualRain]
+    start_rains: Optional[StartRains]
+    end_rains:Optional[EndRains]
+    end_season:Optional[EndSeason]
+    seasonal_rain:Optional[SeasonalRain]
+    seasonal_length: Optional[SeasonalLength]
+
+class AnnualRainfallSummariesdata(BaseModel):
+    station: str
+    year: int
+    start_rains_doy: Optional[int] 
+    start_rains_date: Optional[str] #Should be dates
+    end_rains_doy: Optional[int] 
+    end_rains_date: Optional[str] #Should be dates
+    end_season_doy:Optional[int] 
+    end_season_date:Optional[str] #Should be dates
+    n_seasonal_rain:Optional[int] 
+    season_length: Optional[float] 
+    annual_rain: Optional[float] 
+    n_rain: Optional[int] 
+
+class AnnualRainfallSummariesResponce(BaseModel):
+    metadata: AnnualRainfallSummariesMetadata
+    data: list[AnnualRainfallSummariesdata]

--- a/app/core/responce_models/rainfall_summaries_responce_model.py
+++ b/app/core/responce_models/rainfall_summaries_responce_model.py
@@ -16,11 +16,11 @@ class AnnualRainfallSummariesdata(BaseModel):
     station: str
     year: int
     start_rains_doy: Optional[int] 
-    start_rains_date: Optional[str] #Should be dates
+    start_rains_date: Optional[str] | object #rpy2 has issue with no recognising null strings
     end_rains_doy: Optional[int] 
-    end_rains_date: Optional[str] #Should be dates
+    end_rains_date: Optional[str] | object #rpy2 has issue with no recognising null strings
     end_season_doy:Optional[int] 
-    end_season_date:Optional[str] #Should be dates
+    end_season_date:Optional[str] | object #rpy2 has issue with no recognising null strings
     n_seasonal_rain:Optional[int] 
     season_length: Optional[float] 
     annual_rain: Optional[float] 

--- a/app/core/responce_models/season_start_probabilities.py
+++ b/app/core/responce_models/season_start_probabilities.py
@@ -11,10 +11,11 @@ class SeasonStartProbabilitiesMetadata(BaseModel):
 #ToDo Not used as return structure incorrect
 class SeasonStartProbabilitiesdata(BaseModel):
     station: str
-    proportions : Dict[str, float] 
+    day: int
+    proportion : float
 
 class SeasonStartProbabilitiesResponce(BaseModel):
     metadata: SeasonStartProbabilitiesMetadata
-    data: List[Dict[str, Union[str, float]]] 
+    data: List[SeasonStartProbabilitiesdata]
 
 

--- a/app/core/responce_models/season_start_probabilities.py
+++ b/app/core/responce_models/season_start_probabilities.py
@@ -1,0 +1,20 @@
+from datetime import date
+from pydantic import BaseModel, confloat, conint
+from typing import Dict, List, Optional, Union
+
+from app.core.responce_models.definitions_responce_model import SeasonStartProbabilities, StartRains
+
+class SeasonStartProbabilitiesMetadata(BaseModel):
+    start_rains: Optional[StartRains]
+    season_start_probabilities:Optional[SeasonStartProbabilities]
+
+#ToDo Not used as return structure incorrect
+class SeasonStartProbabilitiesdata(BaseModel):
+    station: str
+    proportions : Dict[str, float] 
+
+class SeasonStartProbabilitiesResponce(BaseModel):
+    metadata: SeasonStartProbabilitiesMetadata
+    data: List[Dict[str, Union[str, float]]] 
+
+

--- a/app/core/responce_models/station_responce_model.py
+++ b/app/core/responce_models/station_responce_model.py
@@ -1,0 +1,33 @@
+from typing import Dict
+from pydantic import BaseModel
+from app.definitions import country_code
+from app.core.responce_models.definitions_responce_model import AnnualRain, CropsSuccess, EndRains, EndSeason, ExtremesRain, ExtremesTemp, SeasonalRain, Temp, SeasonalLength, SeasonalTotalRainfall, StartRains
+
+
+class StationDataResponce(BaseModel):
+    country_code: country_code
+    district: str
+    elevation: int
+    latitude: float
+    longitude: float
+    station_id: int
+    station_name: str 
+
+class StationDefinitionDataResponce(StationDataResponce):
+    start_rains: StartRains
+    end_rains: EndRains
+    end_season : EndSeason
+    seasonal_length : SeasonalLength
+    seasonal_total_rainfall: SeasonalTotalRainfall
+    mean_tmax : Temp
+    mean_tmin : Temp
+    max_tmax : Temp
+    min_tmin : Temp    
+    annual_rain : AnnualRain
+    season_start_probabilities : Dict[str, int] # SeasonStartProbabilities
+    seasonal_rain : SeasonalRain    
+    extremes_tmin : ExtremesTemp
+    extremes_tmax : ExtremesTemp
+    extremes_rain : ExtremesRain
+    crops_success : CropsSuccess
+

--- a/app/core/responce_models/station_responce_model.py
+++ b/app/core/responce_models/station_responce_model.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 from pydantic import BaseModel
 from app.definitions import country_code
 from app.core.responce_models.definitions_responce_model import AnnualRain, CropsSuccess, EndRains, EndSeason, ExtremesRain, ExtremesTemp, SeasonStartProbabilities, SeasonalRain, Temp, SeasonalLength, SeasonalTotalRainfall, StartRains
@@ -14,22 +14,22 @@ class StationDataResponce(BaseModel):
     station_name: str 
 
 class StationDefinitionDataResponce(BaseModel):
-    start_rains: StartRains
-    end_rains: EndRains
-    end_season : EndSeason
-    seasonal_length : SeasonalLength
-    seasonal_total_rainfall: SeasonalTotalRainfall
-    mean_tmax : Temp
-    mean_tmin : Temp
-    max_tmax : Temp
-    min_tmin : Temp    
-    annual_rain : AnnualRain
-    season_start_probabilities : SeasonStartProbabilities
-    seasonal_rain : SeasonalRain    
-    extremes_tmin : ExtremesTemp
-    extremes_tmax : ExtremesTemp
-    extremes_rain : ExtremesRain
-    crops_success : CropsSuccess
+    start_rains: Optional[StartRains]
+    end_rains: Optional[EndRains]
+    end_season : Optional[EndSeason]
+    seasonal_length : Optional[SeasonalLength]
+    seasonal_total_rainfall: Optional[SeasonalTotalRainfall]
+    mean_tmax : Optional[Temp]
+    mean_tmin : Optional[Temp]
+    max_tmax : Optional[Temp]
+    min_tmin : Optional[Temp] 
+    annual_rain : Optional[AnnualRain]
+    season_start_probabilities : Optional[SeasonStartProbabilities]
+    seasonal_rain : Optional[SeasonalRain ]   
+    extremes_tmin : Optional[ExtremesTemp]
+    extremes_tmax : Optional[ExtremesTemp]
+    extremes_rain : Optional[ExtremesRain]
+    crops_success : Optional[CropsSuccess]
 
 class StationAndDefintionResponce(StationDataResponce):
     data : StationDefinitionDataResponce

--- a/app/core/responce_models/station_responce_model.py
+++ b/app/core/responce_models/station_responce_model.py
@@ -1,7 +1,7 @@
 from typing import Dict
 from pydantic import BaseModel
 from app.definitions import country_code
-from app.core.responce_models.definitions_responce_model import AnnualRain, CropsSuccess, EndRains, EndSeason, ExtremesRain, ExtremesTemp, SeasonalRain, Temp, SeasonalLength, SeasonalTotalRainfall, StartRains
+from app.core.responce_models.definitions_responce_model import AnnualRain, CropsSuccess, EndRains, EndSeason, ExtremesRain, ExtremesTemp, SeasonStartProbabilities, SeasonalRain, Temp, SeasonalLength, SeasonalTotalRainfall, StartRains
 
 
 class StationDataResponce(BaseModel):
@@ -13,7 +13,7 @@ class StationDataResponce(BaseModel):
     station_id: int
     station_name: str 
 
-class StationDefinitionDataResponce(StationDataResponce):
+class StationDefinitionDataResponce(BaseModel):
     start_rains: StartRains
     end_rains: EndRains
     end_season : EndSeason
@@ -24,10 +24,13 @@ class StationDefinitionDataResponce(StationDataResponce):
     max_tmax : Temp
     min_tmin : Temp    
     annual_rain : AnnualRain
-    season_start_probabilities : Dict[str, int] # SeasonStartProbabilities
+    season_start_probabilities : SeasonStartProbabilities
     seasonal_rain : SeasonalRain    
     extremes_tmin : ExtremesTemp
     extremes_tmax : ExtremesTemp
     extremes_rain : ExtremesRain
     crops_success : CropsSuccess
+
+class StationAndDefintionResponce(StationDataResponce):
+    data : StationDefinitionDataResponce
 

--- a/app/core/responce_models/temperature_responce_model.py
+++ b/app/core/responce_models/temperature_responce_model.py
@@ -1,0 +1,34 @@
+from datetime import date
+from pydantic import BaseModel
+from typing import List, Optional
+
+from app.core.responce_models.definitions_responce_model import Temp
+
+class TemperatureSummariesMetadata(BaseModel):
+    mean_tmin: Optional[Temp]
+    mean_tmax: Optional[Temp]
+    min_tmin: Optional[Temp] 
+    min_tmax: Optional[Temp]
+    max_tmin: Optional[Temp]
+    max_tmax: Optional[Temp]
+
+class AnnualTempartureSummariesdata(BaseModel):
+    station: str
+    year: int
+    mean_tmin: Optional[float] 
+    mean_tmax: Optional[float] 
+    min_tmin: Optional[float] 
+    min_tmax: Optional[float]
+    max_tmin: Optional[float]
+    max_tmax: Optional[float]
+
+class MonthlyTempartureSummariesdata(AnnualTempartureSummariesdata):
+    month : int
+
+class AnnualTemperatureSummariesResponce(BaseModel):
+    metadata: TemperatureSummariesMetadata
+    data: list[AnnualTempartureSummariesdata]
+
+class MonthlyTemperatureSummariesResponce(BaseModel):
+    metadata: TemperatureSummariesMetadata
+    data: list[MonthlyTempartureSummariesdata]

--- a/app/epicsawrap_link.py
+++ b/app/epicsawrap_link.py
@@ -83,7 +83,7 @@ def extremes_summaries(
 
     __init_data_env()
     r_params: Dict = __get_r_params(locals())
-    r_list_vector: ListVector = r_epicsawrap.overall_extremes_summaries(
+    r_list_vector: ListVector = r_epicsawrap.extremes_summaries(
         country=r_params["country"],
         station_id=r_params["station_id"],
         summaries=r_params["summaries"],
@@ -95,7 +95,6 @@ def annual_rainfall_summaries(
     station_id: str,
     summaries: List[str] = None,
 ) -> OrderedDict:
-    """TODO"""
     if summaries is None:
         summaries = [
             "annual_rain",
@@ -118,7 +117,6 @@ def annual_temperature_summaries(
     station_id: str,
     summaries: List[str] = None,
 ) -> OrderedDict:
-    """TODO"""
     if summaries is None:
         summaries = ["mean_tmin", "mean_tmax", "min_tmin", "min_tmax", "max_tmin", "max_tmax"]
 
@@ -140,7 +138,6 @@ def crop_success_probabilities(
     planting_dates: List[int] = None,
     start_before_season: bool = None,
 ) -> OrderedDict:
-    """TODO"""
     __init_data_env()
     r_params: Dict = __get_r_params(locals())
     r_list_vector: ListVector = r_epicsawrap.crop_success_probabilities(
@@ -159,7 +156,6 @@ def monthly_temperature_summaries(
     station_id: str,
     summaries: List[str] = None,
 ) -> OrderedDict:
-    """TODO"""
     if summaries is None:
         summaries = ["mean_tmin", "mean_tmax", "min_tmin", "min_tmax", "max_tmin", "max_tmax"]
 
@@ -176,7 +172,6 @@ def monthly_temperature_summaries(
 def season_start_probabilities(
     country: str, station_id: str, start_dates: List[int] = None
 ) -> OrderedDict:
-    """TODO"""
     __init_data_env()
     r_params: Dict = __get_r_params(locals())
     r_list_vector: ListVector = r_epicsawrap.season_start_probabilities(
@@ -197,18 +192,23 @@ def station_metadata(
         r_list_vector: RDataFrame = r_epicsawrap.station_metadata(
             include_definitions=r_params["include_definitions"],  
         )
+        data = OrderedDict([("data", __get_data_frame(r_list_vector))])
     elif station_id =="":
-         r_list_vector: RDataFrame = r_epicsawrap.station_metadata(
+        r_list_vector: RDataFrame = r_epicsawrap.station_metadata(
             country=r_params["country"],   
             include_definitions=r_params["include_definitions"],  
         )   
+        data = OrderedDict([("data", __get_data_frame(r_list_vector))])
     else:
         r_list_vector: RDataFrame = r_epicsawrap.station_metadata(
             country=r_params["country"],   
             station_id=r_params["station_id"],
             include_definitions=r_params["include_definitions"],  
+            format = "list",
         )
-    return OrderedDict([("data", __get_data_frame(r_list_vector))])
+        data = __get_python_types(r_list_vector[0])
+
+    return  data
 
 
 
@@ -242,7 +242,6 @@ def __get_data_frame(r_data_frame: RDataFrame) -> DataFrame:
 
 
 def __get_list_vector_as_ordered_dict(r_list_vector: ListVector) -> OrderedDict:
-    """TODO"""
     data_frame = __get_data_frame(r_list_vector[1])
     r_list_as_dict = OrderedDict(
         [
@@ -331,7 +330,6 @@ def __get_r_params(params: Dict) -> Dict:
 
 
 def __init_data_env():
-    """TODO"""
     # ensure that this function is only called once per session
     # (because it relies on the current working folder when session started)
     if not hasattr(__init_data_env, "called"):

--- a/app/epicsawrap_link.py
+++ b/app/epicsawrap_link.py
@@ -120,7 +120,7 @@ def annual_temperature_summaries(
 ) -> OrderedDict:
     """TODO"""
     if summaries is None:
-        summaries = ["mean_tmin", "mean_tmax"]
+        summaries = ["mean_tmin", "mean_tmax", "min_tmin", "min_tmax", "max_tmin", "max_tmax"]
 
     __init_data_env()
     r_params: Dict = __get_r_params(locals())
@@ -161,7 +161,7 @@ def monthly_temperature_summaries(
 ) -> OrderedDict:
     """TODO"""
     if summaries is None:
-        summaries = ["mean_tmin", "mean_tmax"]
+        summaries = ["mean_tmin", "mean_tmax", "min_tmin", "min_tmax", "max_tmin", "max_tmax"]
 
     __init_data_env()
     r_params: Dict = __get_r_params(locals())
@@ -283,9 +283,9 @@ def __get_python_types(data):
         else:
             return OrderedDict(zip(data.names, converted_values))
     elif type(data) in r_list_types:
-        return [__get_python_types(elt) for elt in data]
+        return [__get_python_types(elt) for elt in data][0]
     elif type(data) in r_array_types:
-        return numpy.array(data).tolist()
+        return numpy.array(data).tolist()[0]
     else:
         if hasattr(data, "rclass"):  # An unsupported r class
             raise KeyError(

--- a/app/epicsawrap_link.py
+++ b/app/epicsawrap_link.py
@@ -65,6 +65,7 @@ from rpy2.robjects.vectors import (
     ListVector,
     StrVector,
 )
+from rpy2.rinterface_lib import sexp
 
 r_epicsawrap = packages.importr("epicsawrap")
 r_epicsadata = packages.importr("epicsadata")
@@ -285,10 +286,12 @@ def __get_python_types(data):
         return [__get_python_types(elt) for elt in data][0]
     elif type(data) in r_array_types:
         return numpy.array(data).tolist()[0]
+    elif (type(data) == sexp.NULLType):
+        return None   
     else:
         if hasattr(data, "rclass"):  # An unsupported r class
             raise KeyError(
-                "Could not proceed, type {} is not defined"
+                "Could not proceed, type {} is not defined "
                 "to add support for this type, just add it to the imports "
                 "and to the appropriate type list above".format(type(data))
             )

--- a/app/utils/response.py
+++ b/app/utils/response.py
@@ -1,8 +1,10 @@
+
+import numpy as np
 from pandas import DataFrame
 
 def get_dataframe_response(
     dataframe: DataFrame,
 ):
-    # JSON cannot represent NaN values, so change to space
-    dataframe = dataframe.fillna("")
+    # JSON cannot represent NaN values, so change to None
+    dataframe = dataframe.replace({np.nan:None})
     return dataframe.to_dict(orient="records")

--- a/install_packages_picsa.R
+++ b/install_packages_picsa.R
@@ -12,11 +12,11 @@ if ("epicsawrap" %in% installed_packages) {
     remove.packages("epicsawrap")
 }
 if ("epicsadata" %in% installed_packages) {
-    remove.packages("epicsadata")
+   remove.packages("epicsadata")
 }
 
-devtools::install_github("IDEMSInternational/rpicsa", ref = "9801eaf", force = TRUE)
-devtools::install_github("IDEMSInternational/epicsawrap", ref = "a3a2d37", force = TRUE)
-devtools::install_github("IDEMSInternational/epicsadata", ref = "a943644", force = TRUE)
+devtools::install_github("IDEMSInternational/rpicsa", ref = "ccb2979", force = TRUE)
+devtools::install_github("IDEMSInternational/epicsawrap", ref = "10adb6c", force = TRUE)
+devtools::install_github("IDEMSInternational/epicsadata", ref = "fb98cec", force = TRUE)
 
 q()

--- a/install_packages_picsa.R
+++ b/install_packages_picsa.R
@@ -15,8 +15,8 @@ if ("epicsadata" %in% installed_packages) {
     remove.packages("epicsadata")
 }
 
-devtools::install_github("IDEMSInternational/rpicsa", ref = "c97a873", force = TRUE)
-devtools::install_github("IDEMSInternational/epicsawrap", ref = "89e6fa1", force = TRUE)
-devtools::install_github("IDEMSInternational/epicsadata", ref = "115af84", force = TRUE)
+devtools::install_github("IDEMSInternational/rpicsa", ref = "79ef48d", force = TRUE)
+devtools::install_github("IDEMSInternational/epicsawrap", ref = "21c972f", force = TRUE)
+devtools::install_github("IDEMSInternational/epicsadata", ref = "e13a4bf", force = TRUE)
 
 q()

--- a/install_packages_picsa.R
+++ b/install_packages_picsa.R
@@ -15,8 +15,8 @@ if ("epicsadata" %in% installed_packages) {
     remove.packages("epicsadata")
 }
 
-devtools::install_github("IDEMSInternational/rpicsa", ref = "79ef48d", force = TRUE)
-devtools::install_github("IDEMSInternational/epicsawrap", ref = "21c972f", force = TRUE)
-devtools::install_github("IDEMSInternational/epicsadata", ref = "e13a4bf", force = TRUE)
+devtools::install_github("IDEMSInternational/rpicsa", ref = "9801eaf", force = TRUE)
+devtools::install_github("IDEMSInternational/epicsawrap", ref = "a3a2d37", force = TRUE)
+devtools::install_github("IDEMSInternational/epicsadata", ref = "a943644", force = TRUE)
 
 q()


### PR DESCRIPTION
Added response models for endpoints (not forecasts)
Current issues:
- [ ] annual_rainfall_summaries - if dates aren't present they come back as {} not "" see #36 
- [x] crop_success_probabilities - prop_success always 0
- [ ] monthly_temperature_summaries - error when bringing back all summaries "unexpected value; permitted: 'mean_tmin', 'mean_tmax'"
- [x] season_start_probabilities - data not coming back in rows
- [ ]  season_start_probabilities - probability not going past .4 for test_1
- [ ]  extremes_summaries - Error in (function (daily, data_names, definitions, summaries)
- [x] station data - definitions to come back in the same format as metadata