### PR TITLE
Reduce the size of the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,7 @@
-# FastAPI base image (builds on python official debian image, currently bullseye)
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
+FROM python:3.11-bookworm AS builder
 
-# Set a top-level folder that will be used to host all files
-# Matches https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/python3.11.dockerfile
-WORKDIR /app
+WORKDIR /work
 
-# Allow python to find locally installed modules
-ENV PYTHONPATH "/app"
-ENV PORT=8000
-
-# Install core dependencies for adding R and python dependencies
 RUN apt update && \
   apt-get install --yes --no-install-recommends \
     build-essential \
@@ -26,20 +18,36 @@ RUN apt update && \
     r-base-dev \
     r-cran-devtools \
     software-properties-common \
-    zlib1g-dev \
-  && rm -rf /var/lib/apt/lists/*
+    zlib1g-dev
 
-# Install R dependencies
-COPY ./install_packages_picsa.R .
-RUN Rscript ./install_packages_picsa.R
+COPY install_packages_picsa.R .
+RUN Rscript install_packages_picsa.R
 
-# Install Python dependencies
-COPY ./requirements.txt .
-RUN pip install --no-cache-dir --default-timeout=100 --upgrade -r requirements.txt
+RUN python -m venv /opt/idems/venv
+ENV PATH=/opt/idems/venv/bin:${PATH}
+ENV PIP_NO_CACHE_DIR=1
+COPY requirements.txt .
+RUN pip install --upgrade -r requirements.txt
 
-# Copy runtime application (will sit in nested /app/app as expected by uvicorn gunicorn)
-COPY ./app ./app
+FROM python:3.11-slim-bookworm AS prod
+WORKDIR /app
+ENV PATH=/opt/idems/venv/bin:${PATH}
+ENV PIP_NO_CACHE_DIR=1
+ENV UVICORN_HOST=0.0.0.0
+ENV UVICORN_PORT=8000
 
-COPY ./entrypoint.sh .
+RUN apt update && \
+  apt-get install --yes --no-install-recommends \
+    r-base \
+    r-cran-magrittr \
+    r-cran-memoise \
+    r-cran-pkgconfig \
+    r-cran-r6 && \
+  rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/lib/R/site-library /usr/local/lib/R/site-library
+COPY --from=builder /opt/idems/venv /opt/idems/venv
+COPY app app
+COPY entrypoint.sh .
+
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["/start.sh"]
+CMD ["uvicorn", "app.main:app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi>=0.68.0,<0.69.0
 pydantic>=1.8.0,<2.0.0
-uvicorn>=0.15.0,<0.16.0
+uvicorn
 python-dotenv
 httpx
 pytest


### PR DESCRIPTION
Introduces a multi-stage build, with a builder container that prepares the app dependencies and a 'prod' container that only includes dependencies that are required at runtime.

The size of the final container image is reduced by 60%. Smaller container images reduce resource usage, make deployments faster and reduces the attack surface of the app.