### PR TITLE
Updated metadata response models for temperature summaries

### DIFF
--- a/app/api/v1/endpoints/monthly_temperature_summaries/router.py
+++ b/app/api/v1/endpoints/monthly_temperature_summaries/router.py
@@ -12,7 +12,7 @@ from .schema import (
 router = APIRouter()
 
 
-@router.post("/",response_model=MonthlyTemperatureSummariesResponce)
+@router.post("/")#,response_model=MonthlyTemperatureSummariesResponce)
 def get_monthly_temperature_summaries(
     params: MonthlyTemperatureSummariesParameters,
 ) -> OrderedDict:

--- a/app/core/responce_models/definitions_responce_model.py
+++ b/app/core/responce_models/definitions_responce_model.py
@@ -67,7 +67,7 @@ class SeasonalTotalRainfall(BaseModel):
     na_prop: Optional[float]
 
 class Temp(BaseModel):
-    to: Optional[str]
+    to: Optional[str] | Optional[List[str]]
     na_rm : Optional[bool]
 
 class ExtremesRain(BaseModel):

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ def get_settings():
 
 def get_application():
     settings = get_settings()
-    _app = FastAPI(title="E-PICSA Climate API", version="1.3.1",
+    _app = FastAPI(title="E-PICSA Climate API", version="1.3.2",
                    docs_url="/")
 
     _app.add_middleware(


### PR DESCRIPTION
Updated "to" to be a string or a list of strings

Removed response model for monthly summaries as month comes back as a string for 'zambia_eastern_4'
@lilyclements should month always come back as an integer? 