### PR TITLE
Fixed fastapi version to 0.68.2

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ def get_settings():
 
 def get_application():
     settings = get_settings()
-    _app = FastAPI(title="E-PICSA Climate API", version="1.3.4",
+    _app = FastAPI(title="E-PICSA Climate API", version="1.3.5",
                    docs_url="/")
 
     _app.add_middleware(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
+fastapi==0.68.2
 pydantic>=1.8.0,<2.0.0
 pytest
 requests


### PR DESCRIPTION
This was causing issues with the station endpoint as the version of OpenAPI had changed. 
This is a temporary fix and will be fixed to work with the latest version when response models are re-introduced