### PR TITLE
changed station end points

### DIFF
--- a/app/api/v1/endpoints/station/router.py
+++ b/app/api/v1/endpoints/station/router.py
@@ -10,23 +10,21 @@ router = APIRouter()
 
 @router.get("/")#,response_model=List[StationDataResponce])
 def read_stations() -> OrderedDict:
-    res = run_epicsa_function_and_get_dataframe(
+    return run_epicsa_function_and_get_dataframe(
         station_metadata,
         country="",
         station_id="",
         include_definitions=False,
     )
-    return res['data']
 
 @router.get("/{country}")#,response_model=List[StationDataResponce])
 def read_stations(country: country_code ) -> OrderedDict:
-    res = run_epicsa_function_and_get_dataframe(
+    return run_epicsa_function_and_get_dataframe(
         station_metadata,
         country=country,
         station_id="",
         include_definitions=False,
     )
-    return res['data']
 
 @router.get("/{country}/{station_id}")#,response_model=StationAndDefintionResponce)
 def read_stations(country: country_code, station_id:str ): #-> OrderedDict:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.68.2
+fastapi
 pydantic>=1.8.0,<2.0.0
 pytest
 requests


### PR DESCRIPTION
Changed station end points to return values within data.
Issue with latest OpenAPI Specifications where lists cannot be returned without specifying the model.
Re added the "data" wrapper to solve issue as response model cannot be added due to the incompleteness of data