### PR TITLE
refactor: docs download endpoint

### DIFF
--- a/app/api/v1/endpoints/documents/router.py
+++ b/app/api/v1/endpoints/documents/router.py
@@ -1,10 +1,12 @@
 from typing import Annotated
 from fastapi import APIRouter, HTTPException, Query
-from json import dumps
+from fastapi.responses import StreamingResponse
 from google.cloud import storage
 from google.api_core.page_iterator import HTTPIterator
+from io import BytesIO
 import os
 from .schema import DocumentsGetParameters, DocumentMetadata
+from app.definitions import country_code
 
 client = storage.Client.from_service_account_json('service-account.json')
 
@@ -13,11 +15,11 @@ bucket_name = "epicsa-documents"
 
 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "app/service-account.json"
 
-router = APIRouter()
-
+router = APIRouter() 
 
 @router.get("/{country}")
 def get_documents(
+    country: country_code,
     params:Annotated[DocumentsGetParameters, Query()]
 ) -> list[DocumentMetadata] :
     try:
@@ -26,7 +28,7 @@ def get_documents(
         # NOTE - this is not currently paginated so will only return max 1000 items
         blobs_iterator:HTTPIterator = client.list_blobs(
             bucket_name,
-            prefix=f"{params.country}/{params.prefix}",
+            prefix=f"{country}/{params.prefix}",
             max_results=params.max_results,
             match_glob=params.match_glob)
 
@@ -35,7 +37,7 @@ def get_documents(
         for blob in blobs_iterator:
             # gcs returns blobs as class. Extract fields used in response and append to return entries
             entry = DocumentMetadata(
-                name= blob.name,
+                name= blob.name.replace(f"{country}/","",1),
                 contentType= blob.content_type,
                 size= blob.size,
                 timeCreated= blob.time_created.isoformat(),
@@ -45,3 +47,33 @@ def get_documents(
         return entries
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+def get_file_from_bucket(filename:str):
+    bucket = client.bucket(bucket_name) 
+    blob = bucket.blob(filename)
+    try:
+        return blob.download_as_bytes()
+    except Exception as e:
+        return None     
+    
+# NOTE - as filenames include nested `/` paths use a catch-all for all child routes
+@router.get("/{country}/{filepath:path}")
+def download_document(
+    country: country_code,
+    filepath: str
+) -> list[DocumentMetadata] :
+    """
+    Download a specific document
+    """
+    content = get_file_from_bucket(f"{country}/{filepath}")
+    if content == None:
+        raise HTTPException(status_code=404, detail=f"File not found: {filepath}")
+    if filepath.lower().endswith('.html'):
+        return StreamingResponse(BytesIO(content), 
+                            media_type="application/html", 
+                            headers={"Content-Disposition": f"attachment; filepath={filepath}"})
+    else: # assume pdf if not html
+        return StreamingResponse(BytesIO(content), 
+                            media_type="application/pdf", 
+                            headers={"Content-Disposition": f"attachment; filepath={filepath}"})

--- a/app/api/v1/endpoints/documents/schema.py
+++ b/app/api/v1/endpoints/documents/schema.py
@@ -1,8 +1,6 @@
 from pydantic import BaseModel, Field
-from app.definitions import country_code
 
 class DocumentsGetParameters(BaseModel):
-    country: country_code
     prefix: str = Field(
         default='',
         description='Specify folder path prefixes. Can be used to filter folders timestamped YYYYMMDD, E.g. "202405"',

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@ def get_settings():
 
 def get_application():
     settings = get_settings()
-    _app = FastAPI(title="E-PICSA Climate API", version="1.4.1",
+    _app = FastAPI(title="E-PICSA Climate API", version="1.5.0",
                    docs_url="/")
 
     _app.add_middleware(


### PR DESCRIPTION
Restore code to enable file download of specific documents, via `/documents/{country}/{filename}` endpoint

This was removed during refactor in #61, so have added back with some minor tweaks