### PR TITLE
Feat: rutime upgrades and tidying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.13-bookworm AS builder
 WORKDIR /work
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -18,7 +18,7 @@ RUN gpg --keyserver keyserver.ubuntu.com \
     /etc/apt/sources.list.d/cran40.list
 
 # Install R
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     r-base \
     r-base-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -53,7 +53,12 @@ COPY --from=builder /etc/apt/sources.list.d/cran40.list /etc/apt/sources.list.d/
 
 # Install only runtime R dependencies (no dev tools)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    mariadb-client-core \
     r-base \
+    r-cran-magrittr \
+    r-cran-memoise \
+    r-cran-pkgconfig \
+    r-cran-r6 && \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     r-cran-magrittr \
     r-cran-memoise \
     r-cran-pkgconfig \
-    r-cran-r6 && \
+    r-cran-r6 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,12 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Add R repository key from keyserver
+# Add R repository key and repository
 RUN gpg --keyserver keyserver.ubuntu.com \
     --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' \
     && gpg --armor --export '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' | \
-    gpg --dearmor -o /etc/apt/trusted.gpg.d/cran_debian_key.gpg
-
-# Add R repository
-RUN echo "deb https://cloud.r-project.org/bin/linux/debian bookworm-cran40/" > \
+    gpg --dearmor -o /etc/apt/trusted.gpg.d/cran_debian_key.gpg \
+    && echo "deb https://cloud.r-project.org/bin/linux/debian bookworm-cran40/" > \
     /etc/apt/sources.list.d/cran40.list
 
 # Install R
@@ -54,7 +52,7 @@ COPY --from=builder /etc/apt/trusted.gpg.d/cran_debian_key.gpg /etc/apt/trusted.
 COPY --from=builder /etc/apt/sources.list.d/cran40.list /etc/apt/sources.list.d/
 
 # Install only runtime R dependencies (no dev tools)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     r-base \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,10 +55,6 @@ COPY --from=builder /etc/apt/sources.list.d/cran40.list /etc/apt/sources.list.d/
 RUN apt-get update && apt-get install -y --no-install-recommends \
     mariadb-client-core \
     r-base \
-    r-cran-magrittr \
-    r-cran-memoise \
-    r-cran-pkgconfig \
-    r-cran-r6 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,77 @@
-FROM python:3.11-bookworm AS builder
+# -------- BUILDER STAGE --------
+FROM python:3.13-bookworm AS builder
 
 WORKDIR /work
 
-RUN apt update && \
-  apt-get install --yes --no-install-recommends \
-    build-essential \
-    gcc \
-    libcurl4-openssl-dev \
-    libfribidi-dev \
-    libharfbuzz-dev \
-    libnetcdf-dev \
-    libpq-dev \
-    libssh2-1-dev \
-    libssl-dev \
-    libxml2-dev \
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    gnupg \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add R repository key from keyserver
+RUN gpg --keyserver keyserver.ubuntu.com \
+    --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' \
+    && gpg --armor --export '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' | \
+    gpg --dearmor -o /etc/apt/trusted.gpg.d/cran_debian_key.gpg
+
+# Add R repository
+RUN echo "deb https://cloud.r-project.org/bin/linux/debian bookworm-cran40/" > \
+    /etc/apt/sources.list.d/cran40.list
+
+# Install R
+RUN apt-get update && apt-get install -y \
     r-base \
     r-base-dev \
-    software-properties-common \
-    zlib1g-dev
+    && rm -rf /var/lib/apt/lists/*
 
+# Verify installation (optional)
+RUN R --version
+
+# Install R packages
 COPY install_packages_picsa.R .
 RUN Rscript install_packages_picsa.R
 
+# Set up Python virtual environment
 RUN python -m venv /opt/idems/venv
 ENV PATH=/opt/idems/venv/bin:${PATH}
 ENV PIP_NO_CACHE_DIR=1
 COPY requirements.txt .
 RUN pip install --upgrade -r requirements.txt
 
-FROM python:3.11-slim-bookworm AS prod
+
+# -------- PROD STAGE --------
+FROM python:3.13-slim-bookworm AS prod
 WORKDIR /app
+
 ENV PATH=/opt/idems/venv/bin:${PATH}
 ENV PIP_NO_CACHE_DIR=1
 ENV UVICORN_HOST=0.0.0.0
 ENV UVICORN_PORT=8000
 
-RUN apt update && \
-  apt-get install --yes --no-install-recommends \
-    mariadb-client-core \
+# Copy GPG key and R repository config from builder
+COPY --from=builder /etc/apt/trusted.gpg.d/cran_debian_key.gpg /etc/apt/trusted.gpg.d/
+COPY --from=builder /etc/apt/sources.list.d/cran40.list /etc/apt/sources.list.d/
+
+# Install only runtime R dependencies (no dev tools)
+RUN apt-get update && apt-get install -y \
     r-base \
-    r-cran-magrittr \
-    r-cran-memoise \
-    r-cran-pkgconfig \
-    r-cran-r6 && \
-  rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Copy installed R packages & Python venv from builder
 COPY --from=builder /usr/local/lib/R/site-library /usr/local/lib/R/site-library
 COPY --from=builder /opt/idems/venv /opt/idems/venv
-COPY app app
-COPY entrypoint.sh .
+
+# Create non-root user for security
+RUN groupadd -r appuser && useradd -r -g appuser appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+# Copy app source
+COPY --chown=appuser:appuser app app
+COPY --chown=appuser:appuser entrypoint.sh .
+RUN chmod +x entrypoint.sh
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["uvicorn", "app.main:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt update && \
     libxml2-dev \
     r-base \
     r-base-dev \
-    r-cran-devtools \
     software-properties-common \
     zlib1g-dev
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Build with [FastAPI](https://fastapi.tiangolo.com/)
 
 The api requires Python and R runtimes installed. It has been tested with the versions listed below
 
-- Python (3.11)  
+- Python (3.13)  
   [https://www.python.org/downloads](https://www.python.org/downloads)
 
-- R and Rtools (4.2.3)
+- R and Rtools (4.4.3)
 
   Windows  
-  [https://cran.r-project.org/bin/windows/base/old/4.2.3/](https://cran.r-project.org/bin/windows/base/old/4.2.3/)  
-  [https://cran.r-project.org/bin/windows/Rtools/rtools42/rtools.html](https://cran.r-project.org/bin/windows/Rtools/rtools42/rtools.html)
+  [https://cloud.r-project.org/bin/windows/base/old/](https://cloud.r-project.org/bin/windows/base/old/)  
+  [https://cloud.r-project.org/bin/windows/Rtools/rtools44/rtools.html](https://cloud.r-project.org/bin/windows/Rtools/rtools44/rtools.html)
 
   Linux  
   https://cran.r-project.org/bin/linux/

--- a/install_packages.R
+++ b/install_packages.R
@@ -1,3 +1,3 @@
-install.packages('devtools',repos = "http://cran.us.r-project.org")
+install.packages('pak',repos = "http://cran.us.r-project.org")
 install.packages("rlang",repos = "http://cran.us.r-project.org")
 q()

--- a/install_packages.R
+++ b/install_packages.R
@@ -1,2 +1,2 @@
-install.packages("rlang",repos = "http://cran.us.r-project.org")
+install.packages("rlang",repos = "https://cloud.r-project.org")
 q()

--- a/install_packages.R
+++ b/install_packages.R
@@ -1,3 +1,2 @@
-install.packages('pak',repos = "http://cran.us.r-project.org")
 install.packages("rlang",repos = "http://cran.us.r-project.org")
 q()

--- a/install_packages_picsa.R
+++ b/install_packages_picsa.R
@@ -7,6 +7,7 @@ if ("epicsawrap" %in% installed_packages) {
 
 # Use pak to install packages instead of devtools to install more from pre-compiled binaries
 # and not build everything from source (devtools default setting)
+install.packages('pak',repos = "http://cran.us.r-project.org")
 pak::pak("IDEMSInternational/epicsawrap@607bb9c")
 
 q()

--- a/install_packages_picsa.R
+++ b/install_packages_picsa.R
@@ -5,6 +5,8 @@ if ("epicsawrap" %in% installed_packages) {
     remove.packages("epicsawrap")
 }
 
-devtools::install_github("IDEMSInternational/epicsawrap", ref = "607bb9c", force = TRUE)
+# Use pak to install packages instead of devtools to install more from pre-compiled binaries
+# and not build everything from source (devtools default setting)
+pak::pak("IDEMSInternational/epicsawrap@607bb9c")
 
 q()

--- a/install_packages_picsa.R
+++ b/install_packages_picsa.R
@@ -7,7 +7,7 @@ if ("epicsawrap" %in% installed_packages) {
 
 # Use pak to install packages instead of devtools to install more from pre-compiled binaries
 # and not build everything from source (devtools default setting)
-install.packages('pak',repos = "http://cran.us.r-project.org")
+install.packages('pak',repos = "https://cloud.r-project.org")
 pak::pak("IDEMSInternational/epicsawrap@f3c1988")
 
 q()

--- a/install_packages_picsa.R
+++ b/install_packages_picsa.R
@@ -8,6 +8,6 @@ if ("epicsawrap" %in% installed_packages) {
 # Use pak to install packages instead of devtools to install more from pre-compiled binaries
 # and not build everything from source (devtools default setting)
 install.packages('pak',repos = "http://cran.us.r-project.org")
-pak::pak("IDEMSInternational/epicsawrap@607bb9c")
+pak::pak("IDEMSInternational/epicsawrap@f3c1988")
 
 q()

--- a/install_packages_picsa.R
+++ b/install_packages_picsa.R
@@ -8,6 +8,6 @@ if ("epicsawrap" %in% installed_packages) {
 # Use pak to install packages instead of devtools to install more from pre-compiled binaries
 # and not build everything from source (devtools default setting)
 install.packages('pak',repos = "https://cloud.r-project.org")
-pak::pak("IDEMSInternational/epicsawrap@f3c1988")
+pak::pak("IDEMSInternational/epicsawrap@1e3f5a9")
 
 q()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 fastapi
-httpx
 pydantic>=1.8.0,<2.0.0
 python-dotenv
 pytest
@@ -7,9 +6,6 @@ requests
 pandas
 # Pinned to avoid windows issue: https://github.com/rpy2/rpy2/issues/1104
 rpy2==3.5.12
-pillow
-setuptools
 numpy
-pygeoapi
 google-cloud-storage
 uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+httpx
 pydantic>=1.8.0,<2.0.0
 python-dotenv
 pytest


### PR DESCRIPTION
- Update docs and CI to use python 3.11 -> 3.13
- Update docs and CI to use R 4.2.3 -> 4.4.3
- Replace `devtools` packagement manager for R with `pak`
- Remove legacy dependencies from python requirements
- Update epicsadata to head of https://github.com/IDEMSInternational/epicsawrap/pull/146